### PR TITLE
Fix error if index.php is in the installation url.

### DIFF
--- a/index.php
+++ b/index.php
@@ -419,6 +419,13 @@ else {
     // Get the current url.
     $domain = @( $_SERVER["HTTPS"] != 'on' ) ? 'http://'.$_SERVER["SERVER_NAME"] : 'https://'.$_SERVER["SERVER_NAME"];
     $path = $_SERVER["REQUEST_URI"];
+
+    $path_last_element = end(explode("/", $path));
+    $file_name = end(explode("/", __FILE__));
+    if ($path_last_element === $file_name) {
+        $path = substr ($path, 0, -strlen($path_last_element));
+    }
+
     $url = $domain . $path;
     
     // Check if the install directory is writable.

--- a/index.php
+++ b/index.php
@@ -423,6 +423,13 @@ else {
     $path_last_element = end(explode("/", $path));
     $file_name = end(explode("/", __FILE__));
     if ($path_last_element === $file_name) {
+        /* If the last part of the URI is the same as the
+         * last part of the __FILE__ (the file's name). 
+         * Remove it from the end.
+         *
+         * Using substr() since str_replace() could remove more than 
+         * we would like.
+         */
         $path = substr ($path, 0, -strlen($path_last_element));
     }
 


### PR DESCRIPTION
If when installing, the person used http://domain/index.php, the `$blog_url` in the `config.php` file will contain http://domain/index.php. 

This basically checks the last part of the `REQUEST_URI` and compares it to the last part of `__FILE__`. If they're the same, it is removed from the end of the `REQUEST_URI`.

&nbsp;

The only problem I see with this is if someone installs into a folder named `index.php` or under an alias with that name.