### PR TITLE
Add multiple categories support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ With Dropplets, you write your posts offline (using the text or Markdown editor 
     - Post Author Name (e.g. "Dropplets")
     - Post Author Twitter Handle (e.g. "dropplets")
     - Publish Date in YYYY/MM/DD Format (e.g. "2013/04/28")
-    - Post Category (e.g. "Random Thoughts")
+    - Post Categories (e.g. "Random Thoughts ; Specific Thoughts")
     - Post Status (e.g. "published" or "draft")
 
     Your post text starts here. 

--- a/dropplets/functions.php
+++ b/dropplets/functions.php
@@ -139,11 +139,12 @@ function get_all_posts($options = array()) {
                 // Define the published date.
                 $post_date = str_replace('-', '', $fcontents[3]);
 
-                // Define the post category.
-                $post_category = str_replace(array("\n", '-'), '', $fcontents[4]);
+                // Define the post categories.
+                $post_categories_ = explode(';', str_replace(array("\n", '-'), '', $fcontents[4]));
+                $post_categories_ = array_map(function($el) { return trim($el); }, $post_categories_);
 
                 // Early return if we only want posts from a certain category
-                if($options["category"] && $options["category"] != trim(strtolower($post_category))) {
+                if($options["category"] && !in_array(strtolower($options["category"]), array_map('strtolower', $post_categories_))) {
                     continue;
                 }
 
@@ -157,12 +158,12 @@ function get_all_posts($options = array()) {
                 $post_content = Markdown(join('', array_slice($fcontents, 6, $fcontents.length -1)));
 
                 // Pull everything together for the loop.
-                $files[] = array('fname' => $entry, 'post_title' => $post_title, 'post_author' => $post_author, 'post_author_twitter' => $post_author_twitter, 'post_date' => $post_date, 'post_category' => $post_category, 'post_status' => $post_status, 'post_intro' => $post_intro, 'post_content' => $post_content);
+                $files[] = array('fname' => $entry, 'post_title' => $post_title, 'post_author' => $post_author, 'post_author_twitter' => $post_author_twitter, 'post_date' => $post_date, 'post_categories' => $post_categories_, 'post_status' => $post_status, 'post_intro' => $post_intro, 'post_content' => $post_content);
                 $post_dates[] = $post_date;
                 $post_titles[] = $post_title;
                 $post_authors[] = $post_author;
                 $post_authors_twitter[] = $post_author_twitter;
-                $post_categories[] = $post_category;
+                $post_categories[] = $post_categories_;
                 $post_statuses[] = $post_status;
                 $post_intros[] = $post_intro;
                 $post_contents[] = $post_content;

--- a/dropplets/functions.php
+++ b/dropplets/functions.php
@@ -140,7 +140,7 @@ function get_all_posts($options = array()) {
                 $post_date = str_replace('-', '', $fcontents[3]);
 
                 // Define the post categories.
-                $post_categories_ = explode(';', str_replace(array("\n", '-'), '', $fcontents[4]));
+                $post_categories_ = explode(',', str_replace(array("\n", '-'), '', $fcontents[4]));
                 $post_categories_ = array_map(function($el) { return trim($el); }, $post_categories_);
 
                 // Early return if we only want posts from a certain category

--- a/index.php
+++ b/index.php
@@ -93,11 +93,11 @@ if ($filename==NULL) {
             // Generate the published date.
             $published_date = strftime($date_format, strtotime($published_iso_date));
 
-            // Get the post category.
-            $post_category = $post['post_category'];
+            // Get the post categories.
+            $post_categories = $post['post_categories'];
             
-            // Get the post category link.
-            $post_category_link = $blog_url.'category/'.urlencode(trim(strtolower($post_category)));
+            // Get the post categories links.
+            $post_categories_links = array_map(function($e) { return $blog_url.'category/'.urlencode(trim(strtolower($e))); }, $post_categories);
 
             // Get the post status.
             $post_status = $post['post_status'];
@@ -110,7 +110,7 @@ if ($filename==NULL) {
 
             // Get the post link.
             if ($category) {
-                $post_link = trim(strtolower($post_category)).'/'.str_replace(FILE_EXT, '', $post['fname']);
+                $post_link = trim(strtolower($category)).'/'.str_replace(FILE_EXT, '', $post['fname']); //WTF ?
             } else {
                 $post_link = $blog_url.str_replace(FILE_EXT, '', $post['fname']);
             }
@@ -323,13 +323,14 @@ else {
         $published_date = strftime($date_format, strtotime($published_iso_date));
 
         // Get the post category.
-        $post_category = str_replace(array("\n", '-'), '', $fcontents[4]);
+        $post_categories = explode(';', str_replace(array("\n", '-'), '', $fcontents[4]));
+        $post_categories = array_map(function($el) { return trim($el); }, $post_categories);
         
         // Get the post status.
         $post_status = str_replace(array("\n", '- '), '', $fcontents[5]);
         
-        // Get the post category link.
-        $post_category_link = $blog_url.'category/'.urlencode(trim(strtolower($post_category)));
+        // Get the post categories links.
+        $post_categories_links = array_map(function($e) { return $blog_url.'category/'.urlencode(trim(strtolower($e))); }, $post_categories);
 
         // Get the post link.
         $post_link = $blog_url.str_replace(array(FILE_EXT, POSTS_DIR), '', $filename);

--- a/index.php
+++ b/index.php
@@ -319,7 +319,7 @@ else {
         $published_date = strftime($date_format, strtotime($published_iso_date));
 
         // Get the post category.
-        $post_categories = explode(';', str_replace(array("\n", '-'), '', $fcontents[4]));
+        $post_categories = explode(',', str_replace(array("\n", '-'), '', $fcontents[4]));
         $post_categories = array_map(function($el) { return trim($el); }, $post_categories);
         
         // Get the post status.

--- a/index.php
+++ b/index.php
@@ -109,11 +109,7 @@ if ($filename==NULL) {
             $post_content = $post['post_content'];
 
             // Get the post link.
-            if ($category) {
-                $post_link = trim(strtolower($category)).'/'.str_replace(FILE_EXT, '', $post['fname']); //WTF ?
-            } else {
-                $post_link = $blog_url.str_replace(FILE_EXT, '', $post['fname']);
-            }
+            $post_link = $blog_url.str_replace(FILE_EXT, '', $post['fname']);
 
             // Get the post image url.
             $post_image = get_post_image_url( $post['fname'] ) ?: get_twitter_profile_img($post_author_twitter);

--- a/index.php
+++ b/index.php
@@ -97,7 +97,7 @@ if ($filename==NULL) {
             $post_categories = $post['post_categories'];
             
             // Get the post categories links.
-            $post_categories_links = array_map(function($e) { return $blog_url.'category/'.urlencode(trim(strtolower($e))); }, $post_categories);
+            $post_categories_links = array_map(function($e) { return BLOG_URL.'category/'.urlencode(trim(strtolower($e))); }, $post_categories);
 
             // Get the post status.
             $post_status = $post['post_status'];
@@ -330,7 +330,7 @@ else {
         $post_status = str_replace(array("\n", '- '), '', $fcontents[5]);
         
         // Get the post categories links.
-        $post_categories_links = array_map(function($e) { return $blog_url.'category/'.urlencode(trim(strtolower($e))); }, $post_categories);
+        $post_categories_links = array_map(function($e) { return BLOG_URL.'category/'.urlencode(trim(strtolower($e))); }, $post_categories);
 
         // Get the post link.
         $post_link = $blog_url.str_replace(array(FILE_EXT, POSTS_DIR), '', $filename);

--- a/templates/simple/post.php
+++ b/templates/simple/post.php
@@ -8,7 +8,7 @@
             <ul>
                 <li>Written by <?php echo($post_author); ?></li>
                 <li><?php echo($published_date); ?></li>
-                <li>About <a href="<?php echo($post_category_link); ?>"><?php echo($post_category); ?></a></li>
+                <li>About <?php foreach($post_categories_links as $key => $post_category_link): ?><a href="<?php echo($post_category_link); ?>"><?php echo($post_categories[$key]); ?></a> <?php endforeach; ?></li>
                 <li></li>
             </ul>
         </div>

--- a/templates/simple/posts.php
+++ b/templates/simple/posts.php
@@ -8,7 +8,7 @@
             <ul>
                 <li>Written by <?php echo($post_author); ?></li>
                 <li><?php echo($published_date); ?></li>
-                <li>About <a href="<?php echo($post_category_link); ?>"><?php echo($post_category); ?></a></li>
+                <li>About <?php foreach($post_categories_links as $key => $post_category_link): ?><a href="<?php echo($post_category_link); ?>"><?php echo($post_categories[$key]); ?></a> <?php endforeach; ?></li>
                 <li></li>
             </ul>
         </div>


### PR DESCRIPTION
Just a few changes to allow user to set several categories on a post.

- This doesn't change how categories pages work.
- Backward compatibility : still allow to set a single category
- Posts' links were made unique. No more `domain.tld/category/name/post-link`. (this avoid several issues, and increase SEO ranking for posts)

How to use : 
```
# Your Post Title
- Post Author Name (e.g. "Dropplets")
- Post Author Twitter Handle (e.g. "dropplets")
- Publish Date in YYYY/MM/DD Format (e.g. "2013/04/28")
- Post Categories (e.g. "Random Thoughts ; Specific Thoughts")
- Post Status (e.g. "published" or "draft")

Your post text starts here. 
```