### PR TITLE
Adds post number and total posts to posts listing

### DIFF
--- a/index.php
+++ b/index.php
@@ -72,12 +72,13 @@ if ($filename==NULL) {
     $pagination = ($pagination_on_off != "off") ? get_pagination($page,round(count($all_posts)/ $posts_per_page)) : "";
     define('PAGINATION', $pagination);
     $posts = ($pagination_on_off != "off") ? array_slice($all_posts,$offset,($posts_per_page > 0) ? $posts_per_page : null) : $all_posts;
-
+    $current_post = 0;
+    $total_posts = count($posts);
     if($posts) {
         ob_start();
         $content = '';
         foreach($posts as $post) {
-
+            $current_post++;
             // Get the post title.
             $post_title = str_replace(array("\n",'<h1>','</h1>'), '', $post['post_title']);
 
@@ -107,6 +108,12 @@ if ($filename==NULL) {
 
             // Get the post content
             $post_content = $post['post_content'];
+
+            // Set post number
+            $post_number = $current_post;
+
+            // Set the total posts
+            $post_total_posts = $total_posts;
 
             // Get the post link.
             if ($category) {


### PR DESCRIPTION
### Code

This adds post number and total posts to the `posts.php` page. This helped me do a bit more customization to my posts listing, and was a really simple addition.

### Reasoning
 
In my template for my post listing, I wanted to be able to know the current post number and the total posts. This was so I could build some HTML around the listing to make it display in columns.

This was a super simple addition to the `index.php` file that someone else might find useful, so I thought I'd post the pull request.
