### PR TITLE
Fixing avatar loading

### DIFF
--- a/dropplets/functions.php
+++ b/dropplets/functions.php
@@ -323,6 +323,9 @@ define('IS_SINGLE', !(IS_HOME || IS_CATEGORY));
 /*-----------------------------------------------------------------------------------*/
 
 function get_twitter_profile_img($username) {
+
+    // Pattern for avatar loading service.
+    $avatar_service_pat = 'http://avatars.io/twitter/:username?size=large';
 	
 	// Get the cached profile image.
     $cache = IS_CATEGORY ? '.' : '';
@@ -334,7 +337,7 @@ function get_twitter_profile_img($username) {
 
 	// Cache the image if it doesn't already exist.
 	if (!file_exists($profile_image)) {
-	    $image_url = 'http://dropplets.com/profiles/?id='.$username.'';
+	    $image_url = str_replace(':username', $username, $avatar_service_pat);
 	    $image = file_get_contents($image_url);
 	    file_put_contents($cache.$username.'.jpg', $image);
 	}


### PR DESCRIPTION
As mentioned in #350 and #357, the recent(ish) changes to the Twitter API mean that the avatar loading isn't working so great any more. Fortunately, the good people at [Chute](http://getchute.com) have produced the [avatars.io](http://avatars.io) service that appears to do everything we need for this.